### PR TITLE
Fix issues from interview

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 from flask import Flask, escape, request, jsonify
 import requests
-
+import json
 
 app = Flask(__name__)
 
@@ -18,3 +18,33 @@ def list_sections(brandfolder_slug):
     params = {'search': f'slug:"{brandfolder_slug}"', 'include': 'sections'}
     res = requests.get(url, headers=headers, params=params)
     return jsonify(res.json())
+
+@app.route('/ingest', methods=['POST'])
+def ingest_assets():
+    """
+    Accepts a POST request with a JSON body. Makes POST to Brandfolder assets
+
+    TODO: Validate data
+    """
+    BRANDFOLDER_KEY='pxp6em-11q2fk-1t0s8z'
+    BRANDFOLDER_IMAGES_KEY='pxp6em-11q2fk-6cq2mv'
+    USER_KEY='eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2tleSI6InB4cTdsaS1nNnBpbDQtNnBmZjR1Iiwic3VwZXJ1c2VyIjpmYWxzZX0.A_JyHhzmj4Bm64JeaIAoLOm1c81MnxsXO_UpzYRdGxU'
+    
+    url = 'https://brandfolder.com/api/v4/brandfolders/{}/assets'.format(BRANDFOLDER_KEY)
+    body = {
+        "data": request.json['data'],
+        "section_key": request.json['section_key']
+    }
+    headers = {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer {}'.format(USER_KEY)
+    }
+
+    req = requests.post(url, data=json.dumps(body), headers=headers)
+    try:
+        return jsonify({ 'status': req.status_code, 'msg': req.json() })
+    except:
+        return jsonify({ 'status': req.status_code})
+
+


### PR DESCRIPTION
Debugged the 2 errors preventing a successful post . 

Issue 1: Forgot 'Content-Type: application/json' in my curl request 🤦‍♂️
Issue 2: Did not jsonify (`json.dumps()`) the data field of the Python request.

One point of interest is sending an empty, yet valid JSON object as the data for the request `{}` returns 404 instead 400 from the Brandfolder API. The missing `section_key` is probably causing a failing lookup for resource that isn't there and the 404 supersedes the data validation that would return 400. Because sending just `{"section_key": <:section_key> }` returns the 400 for the malformed request. I'm sure if I  had made it that far in our session, we would have found the middleware API a perfect place to validate the presence of a `section_key` so the user can receive a 400.

I had a great time today, thank you everyone!
